### PR TITLE
don't use the modified value to break the insert after remove

### DIFF
--- a/map.go
+++ b/map.go
@@ -131,7 +131,7 @@ func (imap *IndexMap[K, V]) insert(values ...*V) {
 
 // An UpdateFn modifies the given value,
 // and returns the modified value, they could be the same object,
-// true if the object is modified,
+// true if the object is modified ,
 // false otherwise
 type UpdateFn[V any] func(value *V) (*V, bool)
 
@@ -147,8 +147,8 @@ func (imap *IndexMap[K, V]) Update(key K, updateFn UpdateFn[V]) {
 		imap.remove(key)
 	}
 
-	newV, modified := updateFn(old)
-	if modified && newV != nil {
+	newV, _ := updateFn(old)
+	if newV != nil {
 		imap.insert(newV)
 	}
 }
@@ -170,8 +170,8 @@ func (imap *IndexMap[K, V]) UpdateBy(indexName string, key any, updateFn UpdateF
 	imap.removeValues(oldValues...)
 
 	for _, old := range oldValues {
-		newV, modified := updateFn(old)
-		if modified && newV != nil {
+		newV, _ := updateFn(old)
+		if newV != nil {
 			imap.insert(newV)
 		}
 	}

--- a/map_test.go
+++ b/map_test.go
@@ -193,7 +193,6 @@ func BenchmarkParallelInsertMonlyPrimaryInt(b *testing.B) {
 
 func BenchmarkNativeMap(b *testing.B) {
 	n := len(names)
-	rand.Seed(123)
 	imap := make(map[int64]*Person)
 	for i := 0; i < b.N; i++ {
 		pi := int64(i)


### PR DESCRIPTION
fix a bug which leads in Update calls the a return value with modfied=true, removes the old value but did nor insert the new one